### PR TITLE
Add transaction review labeling flow for personal vs split expenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ docker-compose.override.yml
 
 # IDEs
 .idea/
+
+# Local notes
+idea.rtf

--- a/backend/prisma/migrations/202603130001_transaction_review_state/migration.sql
+++ b/backend/prisma/migrations/202603130001_transaction_review_state/migration.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "transactions"
+ADD COLUMN "reviewState" TEXT NOT NULL DEFAULT 'UNREVIEWED';
+
+UPDATE "transactions"
+SET "reviewState" = CASE
+    WHEN "isPersonal" = false THEN 'SPLIT'
+    ELSE 'PERSONAL'
+END;
+
+CREATE INDEX "transactions_authorId_reviewState_idx"
+ON "transactions"("authorId", "reviewState");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -110,6 +110,7 @@ model Transaction {
 
   // Privacy
   isPersonal Boolean @default(true)
+  reviewState String @default("UNREVIEWED") // UNREVIEWED | PERSONAL | SPLIT
 
   // Renaming history
   originalTitle String? // stores the raw bank SMS/email title
@@ -130,6 +131,7 @@ model Transaction {
 
   @@unique([hash])
   @@index([authorId, date])
+  @@index([authorId, reviewState])
   @@map("transactions")
 }
 

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -141,6 +141,7 @@ async function seed() {
         categoryId: foodCategory ? foodCategory.id : null,
         source: 'MANUAL',
         isPersonal: false,
+        reviewState: 'SPLIT',
         authorId: demoUser.id,
         groupId: group.id,
         hash: `seed-${demoUser.id}-swiggy`,

--- a/backend/src/features/transaction/transactionController.ts
+++ b/backend/src/features/transaction/transactionController.ts
@@ -23,6 +23,7 @@ class TransactionController extends BaseController {
         category?: string;
         type?: string;
         source?: string;
+        reviewState?: string;
         q?: string;
         from?: string;
         to?: string;
@@ -33,11 +34,12 @@ class TransactionController extends BaseController {
         category: query.category,
         type: query.type,
         source: query.source,
+        reviewState: query.reviewState,
         q: query.q,
         from: query.from,
         to: query.to,
-        limit: query.limit ? parseInt(query.limit, 10) : undefined,
-        offset: query.offset ? parseInt(query.offset, 10) : undefined,
+        limit: query.limit ? Number.parseInt(query.limit, 10) : undefined,
+        offset: query.offset ? Number.parseInt(query.offset, 10) : undefined,
       });
 
       return this.ok(result);

--- a/backend/src/features/transaction/transactionRepository.ts
+++ b/backend/src/features/transaction/transactionRepository.ts
@@ -8,6 +8,7 @@ export interface TransactionFilters {
     category?: string;
     type?: string;
     source?: string;
+    reviewState?: string;
     q?: string;
     from?: Date;
     to?: Date;
@@ -25,6 +26,7 @@ export interface CreateTransactionData {
     sourceId?: string | null;
     hash: string;
     isPersonal?: boolean;
+    reviewState?: string;
     category: string;
     date: Date;
     authorId: string;
@@ -39,6 +41,7 @@ export const transactionRepository = {
         if (filters.category) where.category = filters.category;
         if (filters.type) where.type = filters.type;
         if (filters.source) where.source = filters.source;
+        if (filters.reviewState) where.reviewState = filters.reviewState;
         if (filters.from || filters.to) {
             where.date = {};
             if (filters.from) where.date.gte = filters.from;
@@ -90,6 +93,7 @@ export const transactionRepository = {
                 sourceId: data.sourceId ?? null,
                 hash: data.hash,
                 isPersonal: data.isPersonal ?? true,
+                reviewState: data.reviewState ?? 'UNREVIEWED',
                 category: data.category,
                 date: data.date,
                 author: { connect: { id: data.authorId } },
@@ -99,7 +103,7 @@ export const transactionRepository = {
         });
     },
 
-    update(id: string, data: { title?: string; note?: string; category?: string; isPersonal?: boolean; groupId?: string | null }) {
+    update(id: string, data: { title?: string; note?: string; category?: string; isPersonal?: boolean; reviewState?: string; groupId?: string | null }) {
         return prisma.transaction.update({
             where: { id },
             data: {
@@ -107,11 +111,30 @@ export const transactionRepository = {
                 ...(data.note !== undefined && { note: data.note }),
                 ...(data.category !== undefined && { category: data.category }),
                 ...(data.isPersonal !== undefined && { isPersonal: data.isPersonal }),
+                ...(data.reviewState !== undefined && { reviewState: data.reviewState }),
                 ...(data.groupId !== undefined && {
                     group: data.groupId ? { connect: { id: data.groupId } } : { disconnect: true },
                 }),
             },
             include: { splits: true },
+        });
+    },
+
+    markAsPersonal(id: string, data: { title?: string; note?: string; category?: string }) {
+        return prisma.$transaction(async (tx) => {
+            await tx.split.deleteMany({ where: { transactionId: id } });
+            return tx.transaction.update({
+                where: { id },
+                data: {
+                    ...(data.title !== undefined && { title: data.title }),
+                    ...(data.note !== undefined && { note: data.note }),
+                    ...(data.category !== undefined && { category: data.category }),
+                    isPersonal: true,
+                    reviewState: 'PERSONAL',
+                    group: { disconnect: true },
+                },
+                include: { splits: true },
+            });
         });
     },
 
@@ -137,6 +160,47 @@ export const transactionRepository = {
             include: {
                 user: { select: { id: true, name: true, email: true, avatarUrl: true } },
             },
+        });
+    },
+
+    saveSplitConfig(
+        transactionId: string,
+        data: {
+            splits: Array<{ userId: string; amountOwed: number; splitMethod: string }>;
+            groupId?: string | null;
+        }
+    ) {
+        return prisma.$transaction(async (tx) => {
+            await tx.split.deleteMany({ where: { transactionId } });
+
+            const splits = await Promise.all(
+                data.splits.map((split) =>
+                    tx.split.create({
+                        data: {
+                            transactionId,
+                            userId: split.userId,
+                            amountOwed: split.amountOwed,
+                            splitMethod: split.splitMethod,
+                        },
+                        include: {
+                            user: { select: { id: true, name: true, email: true, avatarUrl: true } },
+                        },
+                    })
+                )
+            );
+
+            await tx.transaction.update({
+                where: { id: transactionId },
+                data: {
+                    isPersonal: false,
+                    reviewState: 'SPLIT',
+                    ...(data.groupId !== undefined && {
+                        group: data.groupId ? { connect: { id: data.groupId } } : { disconnect: true },
+                    }),
+                },
+            });
+
+            return splits;
         });
     },
 

--- a/backend/src/features/transaction/transactionSchema.ts
+++ b/backend/src/features/transaction/transactionSchema.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 // ─── Transaction Request Schemas ──────────────────────────────────────────────
 
+const reviewStateSchema = z.enum(['UNREVIEWED', 'PERSONAL', 'SPLIT']);
+
 export const createTransactionSchema = z.object({
     title: z.string().min(1, 'title is required.'),
     amount: z.number().positive('amount must be a positive number.'),
@@ -12,6 +14,7 @@ export const createTransactionSchema = z.object({
     category: z.string().optional(),
     note: z.string().optional(),
     isPersonal: z.boolean().optional(),
+    reviewState: reviewStateSchema.optional(),
     groupId: z.string().uuid().optional(),
     date: z.string().optional(), // ISO date string
 });
@@ -21,6 +24,7 @@ export const updateTransactionSchema = z.object({
     note: z.string().optional(),
     category: z.string().optional(),
     isPersonal: z.boolean().optional(),
+    reviewState: reviewStateSchema.optional(),
     groupId: z.string().uuid().nullable().optional(),
 });
 
@@ -40,6 +44,7 @@ export const addSplitsSchema = z.object({
     ).min(1, 'splits array must not be empty.'),
     method: z.enum(['EQUAL', 'EXACT', 'PERCENT', 'SHARES']).optional().default('EQUAL'),
     totalAmount: z.number().positive('totalAmount must be positive.').optional(),
+    groupId: z.string().uuid().nullable().optional(),
 });
 
 export const createCategoryRuleSchema = z.object({

--- a/backend/src/features/transaction/transactionService.ts
+++ b/backend/src/features/transaction/transactionService.ts
@@ -79,6 +79,7 @@ export const transactionService = {
         category?: string;
         type?: string;
         source?: string;
+        reviewState?: string;
         q?: string;
         from?: string;
         to?: string;
@@ -91,6 +92,7 @@ export const transactionService = {
             category: params.category,
             type: params.type,
             source: params.source,
+            reviewState: params.reviewState,
             q: params.q,
             from: params.from ? new Date(params.from) : undefined,
             to: params.to ? new Date(params.to) : undefined,
@@ -117,6 +119,12 @@ export const transactionService = {
         // Smart auto-categorisation (user rules → system rules)
         const userRules = await transactionRepository.findCategoryRules(params.authorId);
         const finalCategory = params.category || autoCategory(params.title, userRules);
+        const inferredReviewState = params.reviewState
+            ?? (params.isPersonal === false || !!params.groupId
+                ? 'SPLIT'
+                : params.source && params.source !== 'MANUAL'
+                    ? 'UNREVIEWED'
+                    : 'PERSONAL');
 
         return transactionRepository.create({
             title: params.title,
@@ -125,7 +133,8 @@ export const transactionService = {
             source: params.source,
             sourceId: params.sourceId,
             hash,
-            isPersonal: params.isPersonal,
+            isPersonal: params.isPersonal ?? (inferredReviewState !== 'SPLIT'),
+            reviewState: inferredReviewState,
             category: finalCategory,
             note: params.note,
             date: txDate,
@@ -135,6 +144,25 @@ export const transactionService = {
     },
 
     async update(id: string, data: UpdateTransactionRequest) {
+        const nextReviewState = data.reviewState
+            ?? (data.isPersonal === true ? 'PERSONAL' : data.isPersonal === false ? 'SPLIT' : undefined);
+
+        if (nextReviewState === 'PERSONAL') {
+            return transactionRepository.markAsPersonal(id, {
+                title: data.title,
+                note: data.note,
+                category: data.category,
+            });
+        }
+
+        if (nextReviewState === 'SPLIT') {
+            return transactionRepository.update(id, {
+                ...data,
+                isPersonal: false,
+                reviewState: 'SPLIT',
+            });
+        }
+
         return transactionRepository.update(id, data);
     },
 
@@ -169,13 +197,14 @@ export const transactionService = {
             sourceId: parsed.refNo,
             hash,
             isPersonal: true,
+            reviewState: 'UNREVIEWED',
             category,
             date: parsed.date ?? new Date(),
             authorId,
         });
     },
 
-    async addSplits(transactionId: string, { splits, method, totalAmount }: AddSplitsRequest) {
+    async addSplits(transactionId: string, { splits, method, totalAmount, groupId }: AddSplitsRequest) {
         const tx = await transactionRepository.findById(transactionId);
         if (!tx) throw { status: 404, message: 'Transaction not found.' };
 
@@ -185,19 +214,14 @@ export const transactionService = {
             round2(totalAmount ?? tx.amount)
         );
 
-        // Replace any existing splits (re-splitting flow)
-        await transactionRepository.deleteSplitsByTransactionId(transactionId);
-
-        return Promise.all(
-            normalizedSplits.map(s =>
-                transactionRepository.createSplit({
-                    transactionId,
-                    userId: s.userId,
-                    amountOwed: s.amountOwed,
-                    splitMethod: method,
-                })
-            )
-        );
+        return transactionRepository.saveSplitConfig(transactionId, {
+            groupId,
+            splits: normalizedSplits.map((split) => ({
+                userId: split.userId,
+                amountOwed: split.amountOwed,
+                splitMethod: method,
+            })),
+        });
     },
 
     async settleSplit(splitId: string) {

--- a/frontend/app/(tabs)/explore.tsx
+++ b/frontend/app/(tabs)/explore.tsx
@@ -30,6 +30,7 @@ const BORDER = "#1E2D46";
 const ACCENT = "#4F8EF7";
 const GREEN = "#34D399";
 const RED = "#F87171";
+const AMBER = "#FBBF24";
 const MUTED = "#4A5568";
 const TEXT_DIM = "#8B9AB3";
 
@@ -48,6 +49,7 @@ const CATEGORIES = [
 ];
 const TYPES = ["All", "EXPENSE", "INCOME", "TRANSFER"];
 const SOURCES = ["All", "MANUAL", "SMS", "EMAIL", "API"];
+const REVIEW_STATES = ["ALL", "UNREVIEWED", "PERSONAL", "SPLIT"] as const;
 
 const CATEGORY_META: Record<
   string,
@@ -66,6 +68,31 @@ const CATEGORY_META: Record<
 };
 function getMeta(cat: string) {
   return CATEGORY_META[cat] || CATEGORY_META["General"];
+}
+
+function getReviewMeta(tx: Transaction) {
+  if (tx.reviewState === "SPLIT") {
+    const others = tx.splits.filter((split) => split.user.id !== tx.authorId).length;
+    return {
+      label: others > 0 ? `Split · ${others} ${others === 1 ? "person" : "people"}` : "Split",
+      color: ACCENT,
+      background: ACCENT + "22",
+    };
+  }
+
+  if (tx.reviewState === "PERSONAL") {
+    return {
+      label: "Personal",
+      color: GREEN,
+      background: GREEN + "22",
+    };
+  }
+
+  return {
+    label: "Needs Label",
+    color: AMBER,
+    background: AMBER + "22",
+  };
 }
 
 // ─── SMS Modal ────────────────────────────────────────────────────────────────
@@ -324,21 +351,41 @@ function RenameModal({
   tx,
   onClose,
   onSaved,
+  onOpenSplit,
 }: {
   tx: Transaction;
   onClose: () => void;
   onSaved: () => void;
+  onOpenSplit: (tx: Transaction) => void;
 }) {
   const [title, setTitle] = useState(tx.title);
   const [note, setNote] = useState(tx.note || "");
   const [category, setCategory] = useState(tx.category);
-  const [isPersonal, setIsPersonal] = useState(tx.isPersonal);
+  const [decision, setDecision] = useState<"PERSONAL" | "SPLIT" | null>(
+    tx.reviewState === "UNREVIEWED" ? null : tx.reviewState,
+  );
   const [loading, setLoading] = useState(false);
 
   const save = async () => {
+    if (!decision) return;
+
     setLoading(true);
     try {
-      await updateTransaction(tx.id, { title, note, category, isPersonal });
+      if (decision === "SPLIT") {
+        await updateTransaction(tx.id, { title, note, category });
+        onClose();
+        onOpenSplit({ ...tx, title, note, category });
+        return;
+      }
+
+      await updateTransaction(tx.id, {
+        title,
+        note,
+        category,
+        isPersonal: true,
+        reviewState: "PERSONAL",
+        groupId: null,
+      });
       onSaved();
       onClose();
     } catch (_) {
@@ -357,6 +404,10 @@ function RenameModal({
           <Text style={[smsS.sub, { opacity: 0.6 }]}>
             Original: {tx.originalTitle || tx.title}
           </Text>
+          <Text style={smsS.sub}>
+            Label this transaction as personal or split. Once saved, CashSync
+            hides the other path from the list until you edit it again.
+          </Text>
 
           <TextInput
             style={[smsS.input, { minHeight: 0 }]}
@@ -374,25 +425,53 @@ function RenameModal({
             placeholderTextColor="#3D4E68"
             selectionColor={ACCENT}
           />
-          <Pressable
-            onPress={() => setIsPersonal((v) => !v)}
-            style={[
-              smsS.resultBox,
-              {
-                borderColor: isPersonal ? GREEN + "44" : ACCENT + "44",
-                flexDirection: "row",
-                justifyContent: "space-between",
-                alignItems: "center",
-              },
-            ]}
-          >
-            <Text style={{ color: "#fff", fontSize: 13 }}>Personal Use</Text>
-            <Text
-              style={{ color: isPersonal ? GREEN : ACCENT, fontWeight: "700" }}
+          <View style={r.choiceRow}>
+            <Pressable
+              onPress={() => setDecision("PERSONAL")}
+              style={[
+                r.choiceCard,
+                decision === "PERSONAL" && {
+                  borderColor: GREEN,
+                  backgroundColor: GREEN + "14",
+                },
+              ]}
             >
-              {isPersonal ? "ON" : "OFF"}
-            </Text>
-          </Pressable>
+              <Text
+                style={[
+                  r.choiceTitle,
+                  decision === "PERSONAL" && { color: GREEN },
+                ]}
+              >
+                Personal
+              </Text>
+              <Text style={r.choiceBody}>
+                Track it as your own expense, income, or credit.
+              </Text>
+            </Pressable>
+
+            <Pressable
+              onPress={() => setDecision("SPLIT")}
+              style={[
+                r.choiceCard,
+                decision === "SPLIT" && {
+                  borderColor: ACCENT,
+                  backgroundColor: ACCENT + "14",
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  r.choiceTitle,
+                  decision === "SPLIT" && { color: ACCENT },
+                ]}
+              >
+                Split
+              </Text>
+              <Text style={r.choiceBody}>
+                Share it with a group, one person, or multiple people.
+              </Text>
+            </Pressable>
+          </View>
 
           {/* Category picker */}
           <ScrollView
@@ -442,15 +521,42 @@ function RenameModal({
             ))}
           </ScrollView>
 
+          <View
+            style={[
+              smsS.resultBox,
+              {
+                borderColor:
+                  decision === "SPLIT" ? ACCENT + "44" : GREEN + "44",
+              },
+            ]}
+          >
+            <Text style={{ color: "#fff", fontSize: 13 }}>
+              {decision === "SPLIT"
+                ? "Split setup opens next, where you can choose whole group, one person, or multiple people."
+                : decision === "PERSONAL"
+                  ? "Saving as personal clears any existing split and keeps it only in your private cashflow."
+                  : "Choose a label to continue."}
+            </Text>
+          </View>
+
           <View style={smsS.btnRow}>
             <Pressable style={smsS.cancelBtn} onPress={onClose}>
               <Text style={{ color: MUTED, fontWeight: "600" }}>Cancel</Text>
             </Pressable>
-            <Pressable style={smsS.submitBtn} onPress={save} disabled={loading}>
+            <Pressable
+              style={[
+                smsS.submitBtn,
+                !decision && { opacity: 0.5 },
+              ]}
+              onPress={save}
+              disabled={loading || !decision}
+            >
               {loading ? (
                 <ActivityIndicator color="#fff" size="small" />
               ) : (
-                <Text style={smsS.submitText}>Save</Text>
+                <Text style={smsS.submitText}>
+                  {decision === "SPLIT" ? "Continue to Split" : "Save Personal"}
+                </Text>
               )}
             </Pressable>
           </View>
@@ -475,7 +581,18 @@ function SplitModal({
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
     tx.groupId ?? null,
   );
-  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+  const [splitMode, setSplitMode] = useState<"GROUP" | "INDIVIDUAL" | "MULTIPLE">(
+    tx.splits.length === 0
+      ? "GROUP"
+      : tx.splits.length <= 2
+        ? "INDIVIDUAL"
+        : "MULTIPLE",
+  );
+  const [selectedParticipantIds, setSelectedParticipantIds] = useState<string[]>(
+    tx.splits
+      .filter((split) => split.user.id !== authorId)
+      .map((split) => split.user.id),
+  );
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -495,36 +612,67 @@ function SplitModal({
   }, [authorId]);
 
   const selectedGroup = groups.find((g) => g.id === selectedGroupId) || null;
+  const otherMembers =
+    selectedGroup?.members.filter((member) => member.user.id !== authorId) || [];
 
   useEffect(() => {
     if (!selectedGroup) {
-      setSelectedMemberIds([]);
+      setSelectedParticipantIds([]);
       return;
     }
-    setSelectedMemberIds(selectedGroup.members.map((m) => m.user.id));
-  }, [selectedGroupId, selectedGroup?.members.length]);
+    const existingParticipantIds = tx.splits
+      .filter((split) => split.user.id !== authorId)
+      .map((split) => split.user.id)
+      .filter((id) => otherMembers.some((member) => member.user.id === id));
 
-  const toggleMember = (id: string) => {
-    setSelectedMemberIds((prev) =>
+    if (existingParticipantIds.length > 0) {
+      if (splitMode === "INDIVIDUAL") {
+        setSelectedParticipantIds(existingParticipantIds.slice(0, 1));
+        return;
+      }
+
+      if (splitMode === "MULTIPLE") {
+        setSelectedParticipantIds(existingParticipantIds);
+        return;
+      }
+    }
+
+    if (splitMode === "INDIVIDUAL") {
+      setSelectedParticipantIds(otherMembers[0] ? [otherMembers[0].user.id] : []);
+      return;
+    }
+    setSelectedParticipantIds(otherMembers.map((member) => member.user.id));
+  }, [selectedGroupId, selectedGroup?.members.length, splitMode, authorId, tx.splits]);
+
+  const toggleParticipant = (id: string) => {
+    if (splitMode === "INDIVIDUAL") {
+      setSelectedParticipantIds([id]);
+      return;
+    }
+    setSelectedParticipantIds((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
   };
 
+  const splitUserIds = [
+    authorId,
+    ...(splitMode === "GROUP"
+      ? otherMembers.map((member) => member.user.id)
+      : selectedParticipantIds),
+  ];
+
   const save = async () => {
-    if (!selectedGroupId || !selectedMemberIds.length) return;
+    if (!selectedGroupId || splitUserIds.length <= 1) return;
 
     setLoading(true);
     try {
       await addSplits(
         tx.id,
-        selectedMemberIds.map((id) => ({ userId: id })),
+        splitUserIds.map((id) => ({ userId: id })),
         "EQUAL",
         tx.amount,
+        selectedGroupId,
       );
-      await updateTransaction(tx.id, {
-        isPersonal: false,
-        groupId: selectedGroupId,
-      });
       onSaved();
       onClose();
     } catch (_) {
@@ -541,7 +689,10 @@ function SplitModal({
             <Ionicons name="people" size={20} color={ACCENT} /> Split
             Transaction
           </Text>
-          <Text style={smsS.sub}>Pick a group and members by name.</Text>
+          <Text style={smsS.sub}>
+            Choose whether this should be shared with the whole group, one
+            person, or multiple people.
+          </Text>
           <Text style={[smsS.sub, { opacity: 0.7 }]}>
             Amount: ₹{tx.amount.toLocaleString("en-IN")} · Method: Equal split
           </Text>
@@ -579,39 +730,95 @@ function SplitModal({
             ))}
           </ScrollView>
 
+          <View style={r.choiceRow}>
+            {[
+              { id: "GROUP", label: "Group", body: "Everyone in the group" },
+              { id: "INDIVIDUAL", label: "One Person", body: "Split with one person" },
+              { id: "MULTIPLE", label: "Multiple", body: "Choose a few people" },
+            ].map((option) => (
+              <Pressable
+                key={option.id}
+                onPress={() =>
+                  setSplitMode(option.id as "GROUP" | "INDIVIDUAL" | "MULTIPLE")
+                }
+                style={[
+                  r.choiceCard,
+                  splitMode === option.id && {
+                    borderColor: ACCENT,
+                    backgroundColor: ACCENT + "14",
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    r.choiceTitle,
+                    splitMode === option.id && { color: ACCENT },
+                  ]}
+                >
+                  {option.label}
+                </Text>
+                <Text style={r.choiceBody}>{option.body}</Text>
+              </Pressable>
+            ))}
+          </View>
+
           {selectedGroup && (
             <View style={{ gap: 8 }}>
-              <Text style={[smsS.sub, { marginTop: 4 }]}>Members</Text>
-              <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
-                {selectedGroup.members.map((member) => {
-                  const selected = selectedMemberIds.includes(member.user.id);
-                  return (
-                    <Pressable
-                      key={member.id}
-                      onPress={() => toggleMember(member.user.id)}
-                      style={{
-                        paddingHorizontal: 12,
-                        paddingVertical: 8,
-                        borderRadius: 18,
-                        borderWidth: 1,
-                        borderColor: selected ? GREEN : BORDER,
-                        backgroundColor: selected ? GREEN + "22" : CARD_BG,
-                      }}
-                    >
-                      <Text
+              <Text style={[smsS.sub, { marginTop: 4 }]}>
+                {splitMode === "GROUP"
+                  ? `Everyone in ${selectedGroup.name} will be included.`
+                  : splitMode === "INDIVIDUAL"
+                    ? "Choose one person to split with."
+                    : "Choose multiple people to split with."}
+              </Text>
+              {splitMode !== "GROUP" && (
+                <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                  {otherMembers.map((member) => {
+                    const selected = selectedParticipantIds.includes(
+                      member.user.id,
+                    );
+                    return (
+                      <Pressable
+                        key={member.id}
+                        onPress={() => toggleParticipant(member.user.id)}
                         style={{
-                          color: selected ? GREEN : TEXT_DIM,
-                          fontSize: 12,
-                          fontWeight: "700",
+                          paddingHorizontal: 12,
+                          paddingVertical: 8,
+                          borderRadius: 18,
+                          borderWidth: 1,
+                          borderColor: selected ? GREEN : BORDER,
+                          backgroundColor: selected ? GREEN + "22" : CARD_BG,
                         }}
                       >
-                        {member.user.name ||
-                          member.user.email.split("@")[0] ||
-                          "Member"}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
+                        <Text
+                          style={{
+                            color: selected ? GREEN : TEXT_DIM,
+                            fontSize: 12,
+                            fontWeight: "700",
+                          }}
+                        >
+                          {member.user.name ||
+                            member.user.email.split("@")[0] ||
+                            "Member"}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              )}
+              <View
+                style={[
+                  smsS.resultBox,
+                  {
+                    borderColor: ACCENT + "44",
+                  },
+                ]}
+              >
+                <Text style={{ color: "#fff", fontSize: 13 }}>
+                  {splitMode === "GROUP"
+                    ? `CashSync will split this across ${selectedGroup.members.length} people including you.`
+                    : `CashSync will split this across ${splitUserIds.length} people including you.`}
+                </Text>
               </View>
             </View>
           )}
@@ -631,7 +838,7 @@ function SplitModal({
             <Pressable
               style={smsS.submitBtn}
               onPress={save}
-              disabled={loading || !selectedGroup || !selectedMemberIds.length}
+              disabled={loading || !selectedGroup || splitUserIds.length <= 1}
             >
               {loading ? (
                 <ActivityIndicator color="#fff" size="small" />
@@ -655,6 +862,8 @@ export default function ExploreScreen() {
   const [filterCat, setFilterCat] = useState("All");
   const [filterType, setFilterType] = useState("All");
   const [filterSource, setFilterSource] = useState("All");
+  const [filterReviewState, setFilterReviewState] =
+    useState<(typeof REVIEW_STATES)[number]>("ALL");
   const [search, setSearch] = useState("");
   const [dateRange, setDateRange] = useState<"ALL" | "7D" | "30D">("ALL");
   const [smsOpen, setSmsOpen] = useState(false);
@@ -669,6 +878,7 @@ export default function ExploreScreen() {
       if (filterCat !== "All") opts.category = filterCat;
       if (filterType !== "All") opts.type = filterType;
       if (filterSource !== "All") opts.source = filterSource;
+      if (filterReviewState !== "ALL") opts.reviewState = filterReviewState;
       if (search.trim()) opts.q = search.trim();
       if (dateRange !== "ALL") {
         const days = dateRange === "7D" ? 7 : 30;
@@ -681,7 +891,7 @@ export default function ExploreScreen() {
     } finally {
       setLoading(false);
     }
-  }, [user, filterCat, filterType, filterSource, search, dateRange]);
+  }, [user, filterCat, filterType, filterSource, filterReviewState, search, dateRange]);
 
   useEffect(() => {
     fetch();
@@ -766,6 +976,34 @@ export default function ExploreScreen() {
           ))}
         </ScrollView>
 
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={s.pills}
+          style={{ marginBottom: 12 }}
+        >
+          {REVIEW_STATES.map((state) => (
+            <Pressable
+              key={state}
+              onPress={() => setFilterReviewState(state)}
+              style={[s.pill, filterReviewState === state && s.pillActive]}
+            >
+              <Text
+                style={[
+                  s.pillText,
+                  filterReviewState === state && s.pillTextActive,
+                ]}
+              >
+                {state === "ALL"
+                  ? "All Labels"
+                  : state === "UNREVIEWED"
+                    ? "Needs Label"
+                    : state}
+              </Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+
         {/* ── Date filter ── */}
         <ScrollView
           horizontal
@@ -836,11 +1074,7 @@ export default function ExploreScreen() {
           </View>
         ) : (
           transactions.map((tx) => (
-            <Pressable
-              key={tx.id}
-              onLongPress={() => setEditTx(tx)}
-              onPress={() => setSplitTx(tx)}
-            >
+            <Pressable key={tx.id} onPress={() => setEditTx(tx)}>
               <TxCard tx={tx} />
             </Pressable>
           ))
@@ -848,7 +1082,8 @@ export default function ExploreScreen() {
 
         {transactions.length > 0 && (
           <Text style={s.hint}>
-            Tap to split. Long-press to rename or re-categorise.
+            Tap a transaction to label it as personal or split, then edit it
+            anytime if someone tapped the wrong option.
           </Text>
         )}
       </ScrollView>
@@ -867,6 +1102,7 @@ export default function ExploreScreen() {
           tx={editTx}
           onClose={() => setEditTx(null)}
           onSaved={fetch}
+          onOpenSplit={(tx) => setSplitTx(tx)}
         />
       )}
       {splitTx && (
@@ -886,6 +1122,13 @@ export default function ExploreScreen() {
 function TxCard({ tx }: { tx: Transaction }) {
   const isCredit = tx.type === "INCOME";
   const meta = getMeta(tx.category);
+  const review = getReviewMeta(tx);
+  const helperText =
+    tx.reviewState === "UNREVIEWED"
+      ? "Tap to label as Personal or Split"
+      : tx.reviewState === "SPLIT"
+        ? "Tap to manage the split"
+        : "Tap to edit this personal transaction";
   return (
     <View style={c.card}>
       <View style={[c.icon, { backgroundColor: meta.color + "22" }]}>
@@ -900,6 +1143,7 @@ function TxCard({ tx }: { tx: Transaction }) {
             {tx.note}
           </Text>
         ) : null}
+        <Text style={c.helper}>{helperText}</Text>
         <View
           style={{
             flexDirection: "row",
@@ -923,11 +1167,9 @@ function TxCard({ tx }: { tx: Transaction }) {
               <Text style={[c.catText, { color: "#9B59F5" }]}>{tx.source}</Text>
             </View>
           )}
-          {!tx.isPersonal && (
-            <View style={[c.catPill, { backgroundColor: ACCENT + "22" }]}>
-              <Text style={[c.catText, { color: ACCENT }]}>Shared</Text>
-            </View>
-          )}
+          <View style={[c.catPill, { backgroundColor: review.background }]}>
+            <Text style={[c.catText, { color: review.color }]}>{review.label}</Text>
+          </View>
         </View>
       </View>
       <Text style={[c.amount, { color: isCredit ? GREEN : "#fff" }]}>
@@ -959,6 +1201,7 @@ const c = StyleSheet.create({
   info: { flex: 1 },
   title: { fontSize: 15, fontWeight: "700", color: "#fff", marginBottom: 2 },
   note: { fontSize: 12, color: TEXT_DIM, marginBottom: 2 },
+  helper: { fontSize: 11, color: MUTED, marginBottom: 2 },
   date: { fontSize: 11, color: MUTED },
   catPill: {
     backgroundColor: "#ffffff10",
@@ -968,6 +1211,30 @@ const c = StyleSheet.create({
   },
   catText: { fontSize: 10, color: TEXT_DIM, fontWeight: "600" },
   amount: { fontSize: 16, fontWeight: "700", marginLeft: 8 },
+});
+
+const r = StyleSheet.create({
+  choiceRow: {
+    gap: 10,
+  },
+  choiceCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: BORDER,
+    backgroundColor: CARD_BG,
+    padding: 14,
+    gap: 6,
+  },
+  choiceTitle: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "800",
+  },
+  choiceBody: {
+    color: TEXT_DIM,
+    fontSize: 12,
+    lineHeight: 18,
+  },
 });
 
 const s = StyleSheet.create({

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -31,6 +31,7 @@ const CARD_BG = "#1F1F22";
 const BORDER = "#27272A";
 const MUTED = "#A1A1AA";
 const TEXT_DIM = "#D4D4D8";
+const AMBER = "#FBBF24";
 
 // ─── Category Icons ──────────────────────────────────────────────────────────
 
@@ -57,11 +58,22 @@ function getCategoryMeta(cat: string) {
   return CATEGORY_META[cat] || CATEGORY_META["General"];
 }
 
+function getReviewBadge(tx: Transaction) {
+  if (tx.reviewState === "SPLIT") {
+    return { label: "Split", color: ACCENT, background: ACCENT + "22" };
+  }
+  if (tx.reviewState === "PERSONAL") {
+    return { label: "Personal", color: GREEN, background: GREEN + "22" };
+  }
+  return { label: "Needs Label", color: AMBER, background: AMBER + "22" };
+}
+
 // ─── Mini Transaction Row ─────────────────────────────────────────────────────
 
 function TxRow({ tx }: { tx: Transaction }) {
   const isCredit = tx.type === "INCOME";
   const meta = getCategoryMeta(tx.category);
+  const review = getReviewBadge(tx);
   return (
     <View style={txStyles.row}>
       <View style={[txStyles.icon, { backgroundColor: meta.color + "20" }]}>
@@ -83,11 +95,16 @@ function TxRow({ tx }: { tx: Transaction }) {
         <Text style={[txStyles.amount, { color: isCredit ? GREEN : "#fff" }]}>
           {isCredit ? "+" : "−"}₹{tx.amount.toLocaleString("en-IN")}
         </Text>
-        {!tx.isPersonal && (
-          <View style={txStyles.sharedPill}>
-            <Text style={txStyles.sharedText}>Shared</Text>
-          </View>
-        )}
+        <View
+          style={[
+            txStyles.sharedPill,
+            { backgroundColor: review.background },
+          ]}
+        >
+          <Text style={[txStyles.sharedText, { color: review.color }]}>
+            {review.label}
+          </Text>
+        </View>
       </View>
     </View>
   );

--- a/frontend/src/features/transaction/api/transaction.api.ts
+++ b/frontend/src/features/transaction/api/transaction.api.ts
@@ -23,6 +23,7 @@ export interface Transaction {
     category: string;
     source: string;
     isPersonal: boolean;
+    reviewState: 'UNREVIEWED' | 'PERSONAL' | 'SPLIT';
     date: string;
     splits: SplitMember[];
     authorId: string;
@@ -61,6 +62,7 @@ export const getTransactions = async (
         category?: string;
         type?: string;
         source?: string;
+        reviewState?: 'UNREVIEWED' | 'PERSONAL' | 'SPLIT';
         q?: string;
         from?: string;
         to?: string;
@@ -70,6 +72,7 @@ export const getTransactions = async (
     if (opts.category) params.set('category', opts.category);
     if (opts.type) params.set('type', opts.type);
     if (opts.source) params.set('source', opts.source);
+    if (opts.reviewState) params.set('reviewState', opts.reviewState);
     if (opts.q) params.set('q', opts.q);
     if (opts.from) params.set('from', opts.from);
     if (opts.to) params.set('to', opts.to);
@@ -83,6 +86,7 @@ export const createTransaction = async (data: {
     source?: string;
     category?: string;
     isPersonal?: boolean;
+    reviewState?: 'UNREVIEWED' | 'PERSONAL' | 'SPLIT';
     authorId: string;
     note?: string;
     groupId?: string;
@@ -91,7 +95,14 @@ export const createTransaction = async (data: {
 
 export const updateTransaction = async (
     id: string,
-    data: { title?: string; note?: string; category?: string; isPersonal?: boolean; groupId?: string | null }
+    data: {
+        title?: string;
+        note?: string;
+        category?: string;
+        isPersonal?: boolean;
+        reviewState?: 'UNREVIEWED' | 'PERSONAL' | 'SPLIT';
+        groupId?: string | null;
+    }
 ): Promise<Transaction> => req(`/transactions/${id}`, { method: 'PATCH', body: JSON.stringify(data) });
 
 export const ingestSms = async (rawSms: string, authorId: string): Promise<Transaction & { deduplicated?: boolean }> =>
@@ -103,9 +114,10 @@ export const addSplits = async (
     transactionId: string,
     splits: Array<{ userId: string; amountOwed?: number; percentage?: number; shares?: number }>,
     method: 'EQUAL' | 'EXACT' | 'PERCENT' | 'SHARES' = 'EQUAL',
-    totalAmount?: number
+    totalAmount?: number,
+    groupId?: string | null
 ): Promise<SplitMember[]> =>
-    req(`/transactions/${transactionId}/splits`, { method: 'POST', body: JSON.stringify({ splits, method, totalAmount }) });
+    req(`/transactions/${transactionId}/splits`, { method: 'POST', body: JSON.stringify({ splits, method, totalAmount, groupId }) });
 
 export const settleSplit = async (splitId: string): Promise<SplitMember> =>
     req(`/transactions/splits/${splitId}/settle`, { method: 'PATCH' });

--- a/frontend/src/features/transaction/components/TransactionCard.tsx
+++ b/frontend/src/features/transaction/components/TransactionCard.tsx
@@ -28,6 +28,24 @@ export const TransactionCard: React.FC<{ transaction: Transaction }> = ({
     ? `+$${transaction.amount.toFixed(2)}`
     : `-$${transaction.amount.toFixed(2)}`;
   const { emoji, color } = getCategoryIcon(transaction.category || "General");
+  const reviewMeta =
+    transaction.reviewState === "SPLIT"
+      ? {
+          label: "Split",
+          color: "#A1CEDC",
+          background: "rgba(161, 206, 220, 0.1)",
+        }
+      : transaction.reviewState === "PERSONAL"
+        ? {
+            label: "Personal",
+            color: "#39FF14",
+            background: "rgba(57, 255, 20, 0.1)",
+          }
+        : {
+            label: "Needs Label",
+            color: "#FFD93D",
+            background: "rgba(255, 217, 61, 0.12)",
+          };
 
   return (
     <View style={styles.card}>
@@ -50,9 +68,17 @@ export const TransactionCard: React.FC<{ transaction: Transaction }> = ({
         >
           {displayAmount}
         </Text>
-        {!transaction.isPersonal && (
-          <Text style={styles.sharedBadge}>Shared</Text>
-        )}
+        <Text
+          style={[
+            styles.sharedBadge,
+            {
+              color: reviewMeta.color,
+              backgroundColor: reviewMeta.background,
+            },
+          ]}
+        >
+          {reviewMeta.label}
+        </Text>
       </View>
     </View>
   );
@@ -110,9 +136,7 @@ const styles = StyleSheet.create({
   },
   sharedBadge: {
     fontSize: 10,
-    color: "#A1CEDC",
     fontWeight: "600",
-    backgroundColor: "rgba(161, 206, 220, 0.1)",
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 8,


### PR DESCRIPTION
This PR adds a transaction review flow so imported transactions can be labeled as Personal or Split after they are created from SMS, email, manual entry, or future bank API ingestion.

Backend
Added Prisma migration for reviewState
Updated transaction create/update/split flows to keep isPersonal, groupId, and splits in sync
Added filtering support by reviewState
Frontend
Reworked the transaction edit flow to make the Personal vs Split decision explicit
Added a split setup flow for group, one-person, and multi-person sharing
Added review-state badges and filtering in the transactions list